### PR TITLE
Return the object reference after setting CCs in DocumentCreationInfo

### DIFF
--- a/lib/EchoSign/Info/DocumentCreationInfo.php
+++ b/lib/EchoSign/Info/DocumentCreationInfo.php
@@ -31,6 +31,7 @@
             }
             
             $this->ccs = $ccs;
+	    return $this;
         }
         
         function getCCs(){


### PR DESCRIPTION
To allow methods chaining, the setCCs method from DocumentCreationInfo should return the object reference, as all other set\* methods do.
