### PR TITLE
Attaching Multiple Files to a Single Document

### DIFF
--- a/lib/EchoSign/Info/AbstractCreationInfo.php
+++ b/lib/EchoSign/Info/AbstractCreationInfo.php
@@ -4,114 +4,132 @@
 
     class AbstractCreationInfo
     {
-        
+
+		const SIGNATURE_FLOW_SENDER_SIGNATURE_NOT_REQUIRED = 'SENDER_SIGNATURE_NOT_REQUIRED';
+		const SIGNATURE_FLOW_SENDER_SIGNS_LAST = 'SENDER_SIGNS_LAST';
+		const SIGNATURE_FLOW_SENDER_SINGS_FIRST = 'SENDER_SIGNS_FIRST';
+
         protected $name;
-        protected $file;
+        protected $file_infos;
         protected $filename;
         protected $locale;
         protected $signature_flow;
         protected $security_options;
         protected $callback_info;
         protected $merge_fields;
-        
-        function __construct($name, FileInfo $file){
+
+        function __construct($name, FileInfo $file = null){
             $this->name = $name;
-            $this->file = $file;
+			$this->file_infos = new FileInfos($file);
         }
-        
+
         function setName($name){
             $this->name = $name;
             return $this;
         }
-        
+
         function getName(){
             return $this->name;
         }
-        
+
         function setFile(FileInfo $file){
-            $this->file = $file;
+			$this->file_infos = new FileInfos($file);
             return $this;
         }
-        
+
         function getFile(){
-            return $this->file;
+            return $this->file_infos->getFile();
         }
-                
+
+		function addFile(FileInfo $file) {
+			$this->file_infos->addFile($file);
+			return $this;
+		}
+
+		function getFiles() {
+			return $this->file_infos;
+		}
+
+		function setFiles(FileInfos $files) {
+			$this->file_infos = $files;
+			return $this;
+		}
+
         function setLocale($locale){
             $this->locale = $locale;
             return $this;
         }
-        
+
         function getLocale(){
             return $this->locale;
         }
-                
+
         function setSignatureFlow($signature_flow){
-            
-            $allowed = array('SENDER_SIGNATURE_NOT_REQUIRED', 'SENDER_SIGNS_LAST', 'SENDER_SIGNS_FIRST');
-            
+
+            $allowed = array(self::SIGNATURE_FLOW_SENDER_SIGNATURE_NOT_REQUIRED, self::SIGNATURE_FLOW_SENDER_SIGNS_LAST, self::SIGNATURE_FLOW_SENDER_SINGS_FIRST);
+
             if(!in_array($signature_flow, $allowed)){
                 throw new \InvalidArgumentException('signatureFlow must be one of: '.implode(', ', $allowed));
             }
-            
+
             $this->signature_flow = $signature_flow;
             return $this;
         }
-        
+
         function getSignatureFlow(){
             return $this->signature_flow;
         }
-                
+
         function setSecurityOptions(SecurityOptions $security_options){
             $this->security_options = $security_options;
             return $this;
         }
-        
+
         function getSecurityOptions(){
             return $this->security_options;
         }
-                
+
         function setCallbackInfo($callback_url){
-            
+
             if (!filter_var($callback_url, FILTER_VALIDATE_URL)) {
                 throw new \InvalidArgumentException("The callback url is invalid.");
             }
-            
+
             if(!preg_match('#^(http://|https://)#', $callback_url)){
                 $callback_url = 'http://'.$callback_url;
             }
-            
+
             $this->callback_info = $callback_url;
             return $this;
         }
-        
+
         function getCallbackInfo(){
             return $this->callback_info;
         }
-                
+
         function setMergeFields(MergeFieldInfo $merge_fields){
             $this->merge_fields = $merge_fields;
             return $this;
         }
-        
+
         function getMergeFields(){
             return $this->merge_fields;
         }
-        
+
         function asArray(){
-            
+
             $properties = array(
                                     'name' => $this->name,
-                                    'fileInfos' => $this->file->asArray(),
+                                    'fileInfos' => $this->file_infos->asArray(),
                                     'locale' => $this->locale,
                                     'signatureFlow' => $this->signature_flow
                                );
-            
+
             if(!empty($this->callback_info)) $properties['callbackInfo']['signedDocumentUrl'] = $this->callback_info;
             if(!empty($this->security_options)) $properties = array_merge($properties, $this->security_options->asArray());
-            if(!empty($this->merge_fields)) $properties = array_merge($properties, array('mergeFieldInfo' => array('mergeFields' => $this->merge_fields->asArray())));    
-            
+            if(!empty($this->merge_fields)) $properties = array_merge($properties, array('mergeFieldInfo' => array('mergeFields' => $this->merge_fields->asArray())));
+
             return $properties;
-            
+
         }
     }

--- a/lib/EchoSign/Info/AbstractCreationInfo.php
+++ b/lib/EchoSign/Info/AbstractCreationInfo.php
@@ -109,7 +109,7 @@
             
             if(!empty($this->callback_info)) $properties['callbackInfo']['signedDocumentUrl'] = $this->callback_info;
             if(!empty($this->security_options)) $properties = array_merge($properties, $this->security_options->asArray());
-            if(!empty($this->merge_fields)) $properties = array_merge($properties, $this->merge_fields->asArray());
+            if(!empty($this->merge_fields)) $properties = array_merge($properties, array('mergeFieldInfo' => array('mergeFields' => $this->merge_fields->asArray())));    
             
             return $properties;
             

--- a/lib/EchoSign/Info/DocumentCreationInfo.php
+++ b/lib/EchoSign/Info/DocumentCreationInfo.php
@@ -1,10 +1,13 @@
 <?php
 
     namespace EchoSign\Info;
-    
+
     class DocumentCreationInfo extends AbstractCreationInfo
     {
-        
+
+		const SIGNATURE_TYPE_ESIGN = 'ESIGN';
+		const SIGNATURE_TYPE_WRITTEN = 'WRITTEN';
+
         protected $recipients;
         protected $ccs;
         protected $message;
@@ -12,121 +15,121 @@
         protected $external_id;
         protected $reminder_frequency;
         protected $days_until_signing_deadline;
-        
+
         function setRecipients(RecipientInfo $recipients){
             $this->recipients = $recipients;
             return $this;
         }
-        
+
         function getRecipients(){
             return $this->recipients;
         }
-        
+
         function setCCs(array $ccs){
-            
+
             foreach($ccs as $e){
                 if(!filter_var($e, FILTER_VALIDATE_EMAIL)) {
                     throw new \InvalidArgumentException($e. ' is not a valid email');
                 }
             }
-            
+
             $this->ccs = $ccs;
 	    return $this;
         }
-        
+
         function getCCs(){
             return $this->ccs;
         }
-                
+
         function setMessage($message){
             $this->message = $message;
             return $this;
         }
-        
+
         function getMessage(){
             return $this->message;
         }
-        
+
         function setSignatureType($signature_type){
-            
-            $allowed = array('ESIGN', 'WRITTEN');
-            
+
+            $allowed = array(self::SIGNATURE_TYPE_ESIGN, self::SIGNATURE_TYPE_WRITTEN);
+
             if(!in_array($signature_type, $allowed)){
                 throw new \InvalidArgumentException('signatureType must be one of: '.implode(', ', $allowed));
             }
-            
+
             $this->signature_type = $signature_type;
             return $this;
         }
-        
+
         function getSignatureType(){
             return $this->signature_type;
         }
-        
+
         function setExternalId($external_id){
             $this->external_id = $external_id;
             return $this;
         }
-        
+
         function getExternalId(){
             return $this->external_id;
         }
-                
+
         function setReminderFrequency($reminder_frequency){
-            
+
             $allowed = array('DAILY_UNTIL_SIGNED', 'WEEKLY_UNTIL_SIGNED');
-            
+
             if(!in_array($reminder_frequency, $allowed)){
                 throw new \InvalidArgumentException('ReminderFrequency must be one of: '.implode(', ', $allowed));
             }
-            
+
             $this->reminder_frequency = $reminder_frequency;
             return $this;
         }
-        
+
         function getReminderFrequency(){
             return $this->reminder_frequency;
         }
-                
+
         function setDaysUntilSigningDeadline($days){
-            
+
             if(!filter_var($days, FILTER_VALIDATE_INT)) {
                 throw new \InvalidArgumentException('DaysUntilSigningDeadline must be an integer');
             }
-            
+
             $this->days_until_signing_deadline = $days;
             return $this;
         }
-        
+
         function getDaysUntilSigningDeadline(){
             return $this->days_until_signing_deadline;
         }
-        
+
         function asArray(){
-            
+
             $inherited = parent::asArray();
-            
+
             $properties = array(
-                            
+
                             'recipients' => $this->recipients->asArray(),
                             'ccs' => $this->ccs,
                             'message' => $this->message,
                             'signatureType' => $this->signature_type,
                             'reminderFrequency' => $this->reminder_frequency,
                             'daysUntilSigningDeadline' => $this->days_until_signing_deadline
-                
+
                         );
-            
+
             $properties = array_merge($inherited, $properties);
-            
+
             foreach($properties as $k => $v){
                 if($v === null || $v === ''){
                     unset($properties[$k]);
                 }
             }
-            
+
             return array('documentCreationInfo' => $properties);
-            
+
         }
-        
+
     }

--- a/lib/EchoSign/Info/FileInfo.php
+++ b/lib/EchoSign/Info/FileInfo.php
@@ -1,106 +1,124 @@
 <?php
 
     namespace EchoSign\Info;
-    
+
     class FileInfo
     {
-        
+
         protected $filename;
         protected $mime_type;
         protected $file;
         protected $url;
         protected $library_document_key;
         protected $library_document_name;
-        
+
         static function createFromFile($file, $filename = null){
-            
+
             $f = pathinfo($file);
-            
+
             $fileInfo = new self;
             $fileInfo->setFile($file)
                      ->setMimeType(static::getMimeByExtension($f['extension']))
                      ->setFilename((!empty($filename) ? $filename : $f['filename'].'.'.$f['extension']));
             return $fileInfo;
         }
-        
+
+		static function createFromUrl($url, $filename = null){
+
+            $u = parse_url($url);
+			$f = $u['path'];
+			if(isset($u['query'])) {
+				$f .= '?' . $u['query'];
+			}
+			if(isset($u['fragment'])) {
+				$f .= '#' . $u['fragment'];
+			}
+
+            $fileInfo = new self;
+            $fileInfo->setUrl($url)
+                     ->setMimeType('application/pdf')
+                     ->setFilename((!empty($filename) ? $filename : $f));
+            return $fileInfo;
+		}
+
         static function createFromLibraryDocumentKey($library_document_key){
             $fileInfo = new self;
             $fileInfo->setLibraryDocumentKey($library_document_key);
             return $fileInfo;
         }
-        
+
         static function createFromLibraryDocumentName($library_document_name){
             $fileInfo = new self;
             $fileInfo->setLibraryDocumentName($library_document_name);
             return $fileInfo;
         }
-        
+
         function setFilename($filename){
             $this->filename = $filename;
             return $this;
         }
-        
+
         function getFilename(){
             return $this->filename;
         }
-        
+
         function setMimeType($mime_type){
-            
+
             if(!in_array($mime_type, static::getMimeTypes())){
                 throw new \InvalidArgumentException($mime_type . ' is not a supported mime type');
             }
-            
+
             $this->mime_type = $mime_type;
             return $this;
         }
-        
+
         function getMimeType(){
             return $this->mime_type;
         }
-        
+
         function setFile($file){
-            
+
             $f = pathinfo($file);
-            
+
             $this->file = $file;
             $this->setMimeType(static::getMimeByExtension($f['extension']));
-            
+
             return $this;
         }
-        
+
         function getFile(){
             return $this->file;
         }
-        
+
         function setUrl($url){
             $this->url = $url;
             return $this;
         }
-        
+
         function getUrl(){
             return $this->url;
         }
-        
+
         function setLibraryDocumentKey($library_document_key){
             $this->library_document_key = $library_document_key;
             return $this;
         }
-        
+
         function getLibraryDocumentKey(){
             return $this->library_document_key;
         }
-        
+
         function setLibraryDocumentName($library_document_name){
             $this->library_document_name = $library_document_name;
             return $this;
         }
-        
+
         function getLibraryDocumentName(){
             return $this->library_document_name;
         }
-        
+
         function asArray(){
-            
+
             $properties = array(
                             'fileName' => $this->filename,
                             'mimeType' => $this->mime_type,
@@ -109,31 +127,31 @@
                             'libraryDocumentKey' => $this->library_document_key,
                             'libraryDocumentName' => $this->library_document_name
                         );
-            
+
             foreach($properties as $k => $v){
                 if($v === null || $v === ''){
                     unset($properties[$k]);
                 }
             }
-            
-            return array('FileInfo' => $properties);
-            
+
+            return $properties;
+
         }
-        
+
         static function getMimeByExtension($ext){
-            
+
             $types = static::getMimeTypes();
-            
+
             if(in_array($ext, array_keys($types))){
                 return $types[$ext];
             }
-            
+
             throw new \InvalidArgumentException('.' .$ext. ' is not a supported extension');
-            
+
         }
-        
+
         protected static function getMimeTypes(){
-            
+
             return array(
                             'pdf' => 'application/pdf',
                             'doc' => 'application/msword',
@@ -144,5 +162,5 @@
                             'pptx' => 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
                           );
         }
-        
+
     }

--- a/lib/EchoSign/Info/FileInfos.php
+++ b/lib/EchoSign/Info/FileInfos.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace EchoSign\Info;
+
+class FileInfos {
+
+	protected $file_infos = array();
+
+	function __construct(FileInfo $fileInfo = null) {
+		if($fileInfo) {
+			$this->file_infos[] = $fileInfo;
+		}
+	}
+
+	function addFile(FileInfo $fileInfo) {
+		$this->file_infos[] = $fileInfo;
+	}
+
+	function getFile() {
+		return isset($this->file_infos[0]) ? $this->file_infos[0] : null;
+	}
+
+	function setFile(FileInfo $fileInfo) {
+		$this->file_infos = array($fileInfo);
+	}
+
+	function asArray() {
+
+		$fileInfos = array();
+		foreach ($this->file_infos as $fileInfo) {
+			$fileInfos[] = $fileInfo->asArray();
+		}
+
+		return $fileInfos;
+	}
+
+}


### PR DESCRIPTION
I modified the code to allow users to attach multiple files to a single document, as per the EchoSign API specification.

The code should be backwards compatible with existing projects that use single-file documents, and preserve the functionality of the constructor, getFile() and setFile().
